### PR TITLE
Implement password input filtering with Zod validation

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -216,6 +216,7 @@ function GameContent() {
 
             <HackingConsole
               length={passwordLength}
+              charset={config.charset}
               disabled={
                 !user ||
                 currentCP <= 0 ||

--- a/lib/charset.ts
+++ b/lib/charset.ts
@@ -2,6 +2,8 @@
  * Charset utilities for frontend display
  */
 
+import { z } from "zod";
+
 export type CharsetType = "lowercase" | "uppercase" | "alphanumeric" | "symbols";
 
 export const CHARSET_LABELS: Record<CharsetType, { short: string; full: string }> = {
@@ -9,6 +11,16 @@ export const CHARSET_LABELS: Record<CharsetType, { short: string; full: string }
   uppercase: { short: "A-Z", full: "Uppercase (A-Z)" },
   alphanumeric: { short: "0-9", full: "Numbers (0-9)" },
   symbols: { short: "!@#", full: "Symbols (!@#$...)" },
+};
+
+/**
+ * Maps charset types to their actual character strings
+ */
+export const CHARSET_MAP: Record<CharsetType, string> = {
+  lowercase: "abcdefghijklmnopqrstuvwxyz",
+  uppercase: "ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+  alphanumeric: "0123456789",
+  symbols: "!@#$%^&*()_+-=[]{}|;:,.<>?",
 };
 
 export const ALL_CHARSET_TYPES: CharsetType[] = [
@@ -43,4 +55,52 @@ export function formatCharsetDisplayFull(charset: CharsetType[]): string {
  */
 export function isCharsetEnabled(charset: CharsetType[], type: CharsetType): boolean {
   return charset.includes(type);
+}
+
+/**
+ * Builds a combined charset string from an array of charset types
+ * @example buildCharset(['lowercase', 'alphanumeric']) => 'abcdefghijklmnopqrstuvwxyz0123456789'
+ */
+export function buildCharset(charsetTypes: CharsetType[]): string {
+  return charsetTypes.map((type) => CHARSET_MAP[type]).join("");
+}
+
+/**
+ * Checks if a character is allowed based on the charset types
+ */
+export function isCharAllowed(char: string, charsetTypes: CharsetType[]): boolean {
+  const allowedChars = buildCharset(charsetTypes);
+  return allowedChars.includes(char);
+}
+
+/**
+ * Filters a string to only include allowed characters
+ */
+export function filterAllowedChars(value: string, charsetTypes: CharsetType[]): string {
+  const allowedChars = buildCharset(charsetTypes);
+  return value
+    .split("")
+    .filter((char) => allowedChars.includes(char))
+    .join("");
+}
+
+/**
+ * Creates a Zod schema for password validation based on charset and length
+ */
+export function createPasswordSchema(charsetTypes: CharsetType[], length: number) {
+  const allowedChars = buildCharset(charsetTypes);
+  const regex = new RegExp(`^[${escapeRegex(allowedChars)}]{${length}}$`);
+
+  return z.string()
+    .length(length, { message: `Password must be exactly ${length} characters` })
+    .regex(regex, {
+      message: `Password can only contain characters from: ${formatCharsetDisplay(charsetTypes)}`
+    });
+}
+
+/**
+ * Escapes special regex characters for use in RegExp
+ */
+function escapeRegex(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "motion": "^12.26.2",
     "next": "16.1.1",
     "react": "19.2.3",
-    "react-dom": "19.2.3"
+    "react-dom": "19.2.3",
+    "zod": "^4.3.5"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       react-dom:
         specifier: 19.2.3
         version: 19.2.3(react@19.2.3)
+      zod:
+        specifier: ^4.3.5
+        version: 4.3.5
     devDependencies:
       '@tailwindcss/postcss':
         specifier: ^4


### PR DESCRIPTION
Add character filtering and validation for password input based on block's charset rules:
- Install zod package for schema validation
- Add CHARSET_MAP and utility functions to lib/charset.ts
- Update HackingConsole to filter disallowed characters on input
- Add Zod validation on submit with error message display
- Pass charset prop from page.tsx to HackingConsole
- Display allowed characters info in the console UI