### PR TITLE
익명 사용자 정책 개선 및 Prisma 7 마이그레이션

### DIFF
--- a/apps/api/.gitignore
+++ b/apps/api/.gitignore
@@ -54,6 +54,3 @@ pids
 
 # Diagnostic reports (https://nodejs.org/api/report.html)
 report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
-
-# Prisma
-/prisma/generated

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -2,8 +2,7 @@
 // learn more about it in the docs: https://pris.ly/d/prisma-schema
 
 generator client {
-  provider = "prisma-client"
-  output   = "./generated/prisma"
+  provider = "prisma-client-js"
 }
 
 datasource db {

--- a/apps/api/prisma/seed.ts
+++ b/apps/api/prisma/seed.ts
@@ -1,4 +1,4 @@
-import { PrismaClient } from './generated/prisma';
+import { PrismaClient } from '@prisma/client';
 import { PrismaPg } from '@prisma/adapter-pg';
 import { Pool } from 'pg';
 

--- a/apps/api/scripts/migrate-from-supabase.ts
+++ b/apps/api/scripts/migrate-from-supabase.ts
@@ -1,5 +1,5 @@
 import { createClient } from '@supabase/supabase-js';
-import { PrismaClient } from '../prisma/generated/prisma';
+import { PrismaClient } from '@prisma/client';
 import { PrismaPg } from '@prisma/adapter-pg';
 import { Pool } from 'pg';
 

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import { ConfigService } from '@nestjs/config';
-import { User } from '../../prisma/generated/prisma';
+import { User } from '@prisma/client';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import * as bcrypt from 'bcrypt';
 

--- a/apps/api/src/shared/database/prisma.service.ts
+++ b/apps/api/src/shared/database/prisma.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
-import { PrismaClient } from '../../../prisma/generated/prisma';
+import { PrismaClient } from '@prisma/client';
 import { ConfigService } from '@nestjs/config';
 import { PrismaPg } from '@prisma/adapter-pg';
 import { Pool } from 'pg';


### PR DESCRIPTION
## 요약

익명 사용자가 일반 사용자와 동일하게 동작하도록 백엔드 API를 개선하고, Prisma 7 클라이언트 형식으로 마이그레이션했습니다.

## 주요 변경사항

### 1. Prisma 7 마이그레이션
- `schema.prisma` 생성기를 `provider = "prisma-client"`로 업데이트
- 커스텀 출력 경로 `./generated/prisma` 설정
- 4개 파일의 import 경로를 생성된 클라이언트 상대 경로로 업데이트

### 2. 익명 사용자 랭킹 포함
- `ranking.service.ts`에서 `isAnonymous: false` 필터 4곳 제거
- 익명 사용자가 이제 랭킹에 표시됨

### 3. 익명 사용자 힌트 설정 허용
- `blocks.service.ts`에서 익명 사용자 조건부 로직 제거
- 모든 우승자(익명 포함)가 `WAITING_HINT` 상태를 받고 힌트를 설정할 수 있음

### 4. 익명 사용자 업그레이드 API
- `UpgradeAnonymousUserDto` 추가 (이메일, 비밀번호, 닉네임 검증)
- `upgradeAnonymousUser()` 서비스 메서드 구현
  - P2002 에러 처리 (이메일/닉네임 중복)
  - 세션 삭제 및 CP 한도 50으로 업그레이드
- `PUT /users/upgrade` 엔드포인트 추가

## 기술적 세부사항

### Prisma 7 마이그레이션
- 생성된 클라이언트 위치: `apps/api/prisma/generated/prisma/`
- 소스 파일에 `@prisma/client` import 없음 (생성된 코드 제외)

### 익명 사용자 정책
- **랭킹**: 익명 사용자 포함
- **힌트 설정**: 익명 우승자 허용
- **CP 한도**: 익명 5 → 정식 50 (업그레이드 시)
- **업그레이드**: 이메일, 비밀번호, 닉네임 필수

### 에러 처리
- P2002: 이메일/닉네임 중복 시 409 Conflict
- 404: 사용자 없음
- 400: 이미 정식 사용자

## 검증

- ✅ Prisma 클라이언트 생성 성공
- ✅ 소스 파일에 `@prisma/client` import 없음
- ✅ 랭킹 서비스에서 익명 필터 제거됨
- ✅ 블록 서비스에서 익명 조건부 로직 제거됨
- ✅ 업그레이드 DTO 및 엔드포인트 추가됨

## 커밋

1. `chore(api): migrate to Prisma 7 client format` (0c5c66a)
2. `fix(api): include anonymous users in rankings and allow hint setting` (055884c)
3. `feat(api): add anonymous user upgrade functionality` (4f855c0)

## 참고사항

- 테스트 추가는 별도 PR에서 진행 예정 (테스트 인프라 설정 필요)
- 모든 변경사항은 `apps/api` 디렉토리에 국한됨