### PR TITLE
block 어댑터: ID/포인트 정규화 및 누락 필드 안전 처리

### DIFF
--- a/apps/web/shared/api/adapters/block-adapter.ts
+++ b/apps/web/shared/api/adapters/block-adapter.ts
@@ -2,18 +2,18 @@ import type { Block, BlockStatus, BlockWithNicknames } from '@/entities/block';
 import type { CharsetType } from '@/shared/lib/charset';
 
 export interface ApiBlock {
-  id: number;
+  id: number | string;
   status: string;
   seedHint: string | null;
   difficultyConfig: {
     length: number;
     charset: CharsetType[];
   };
-  winnerId: string | null;
+  winnerId?: string | null;
   createdAt: string;
-  solvedAt: string | null;
-  createdBy: string | null;
-  accumulatedPoints: number;
+  solvedAt?: string | null;
+  createdBy?: string | null;
+  accumulatedPoints: number | string;
   solvedAttemptId?: string | null;
 }
 
@@ -51,16 +51,19 @@ export function adaptBlockStatus(status: string): BlockStatus {
 }
 
 export function adaptBlock(apiBlock: ApiBlock): Block {
+  const normalizedId = Number(apiBlock.id);
+  const accumulatedPoints = Number(apiBlock.accumulatedPoints);
+
   return {
-    id: apiBlock.id,
+    id: Number.isFinite(normalizedId) ? normalizedId : 0,
     status: adaptBlockStatus(apiBlock.status),
     seed_hint: apiBlock.seedHint,
     difficulty_config: apiBlock.difficultyConfig,
-    winner_id: apiBlock.winnerId,
+    winner_id: apiBlock.winnerId ?? null,
     created_at: apiBlock.createdAt,
-    solved_at: apiBlock.solvedAt,
-    created_by: apiBlock.createdBy,
-    accumulated_points: apiBlock.accumulatedPoints,
+    solved_at: apiBlock.solvedAt ?? null,
+    created_by: apiBlock.createdBy ?? null,
+    accumulated_points: Number.isFinite(accumulatedPoints) ? accumulatedPoints : 0,
     solved_attempt_id: apiBlock.solvedAttemptId,
   };
 }


### PR DESCRIPTION
### Motivation
- 클라이언트에서 `/game/current` 등 백엔드 응답이 문자열 타입(`id`, `accumulatedPoints`)이나 일부 optional 필드를 생략해 내려올 때 숫자 연산 및 필드 접근에서 오류가 발생해 UI가 불안정해질 수 있어 이를 방지하기 위함입니다.

### Description
- `ApiBlock` 타입을 업데이트해 `id`를 `number | string`으로, `accumulatedPoints`를 `number | string`으로 허용하고 `winnerId`, `solvedAt`, `createdBy`를 optional로 변경했습니다.
- `adaptBlock`에서 `id`와 `accumulatedPoints`를 `Number(...)`로 정규화하고 숫자로 변환 불가능한 경우 안전한 기본값(`0`)으로 대체하도록 처리했습니다.
- 누락된 식별자/문자열 필드들은 `null` 또는 적절한 기본값으로 보정해 클라이언트에서의 안전한 사용을 보장하도록 변경했습니다 (`adaptSSECurrentBlock` 동작은 유지됨).

### Testing
- 자동화된 테스트는 실행하지 않았습니다.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698457f3ef888320913a26a387945ac0)